### PR TITLE
Automated cherry pick of #52: Change release repo to docker.io, add RELEASE and CONFIRM env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ SEMAPHORE_PROJECT_ID?=$(SEMAPHORE_API_SERVER_OSS_PROJECT_ID)
 
 API_SERVER_IMAGE      ?=calico/apiserver
 BUILD_IMAGES          ?=$(API_SERVER_IMAGE)
-DEV_REGISTRIES        ?=quay.io registry.hub.docker.com
+DEV_REGISTRIES        ?=quay.io docker.io
 RELEASE_REGISTRIES    ?=$(DEV_REGISTRIES)
 RELEASE_BRANCH_PREFIX ?=release
 DEV_TAG_SUFFIX        ?=0.dev
@@ -393,7 +393,7 @@ release-publish: release-prereqs
 	git push origin $(VERSION)
 
 	# Push images.
-	$(MAKE) push-images-to-registries push-manifests IMAGETAG=$(VERSION)
+	$(MAKE) push-images-to-registries push-manifests IMAGETAG=$(VERSION) RELEASE=true CONFIRM=true
 
 	@echo "Finalize the GitHub release based on the pushed tag."
 	@echo ""
@@ -408,7 +408,7 @@ release-publish: release-prereqs
 # run this target for alpha / beta / release candidate builds, or patches to earlier Calico versions.
 ## Pushes `latest` release images. WARNING: Only run this for latest stable releases.
 release-publish-latest: release-prereqs
-	$(MAKE) push-images-to-registries push-manifests IMAGETAG=latest
+	$(MAKE) push-images-to-registries push-manifests IMAGETAG=latest RELEASE=true CONFIRM=true
 
 # release-prereqs checks that the environment is configured properly to create a release.
 release-prereqs:


### PR DESCRIPTION
Cherry pick of #52 on release-v3.20.

#52: Change release repo to docker.io, add RELEASE and CONFIRM env