### PR TITLE
arm64 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ Makefile.common.$(MAKE_BRANCH):
 include Makefile.common
 
 # We need CGO to leverage Boring SSL.  However, the cross-compile doesn't support CGO yet.
-ifeq ($(ARCH), $(filter $(ARCH),amd64))
+ifeq ($(ARCH), $(filter $(ARCH),amd64 arm64))
 CGO_ENABLED=1
 else
 CGO_ENABLED=0
@@ -143,8 +143,8 @@ else
 endif
 	@echo Building k8sapiserver...
 	mkdir -p bin
-	$(DOCKER_RUN) -e CGO_ENABLED=$(CGO_ENABLED) $(CALICO_BUILD) \
-		sh -c '$(GIT_CONFIG_SSH) go build -v -i -o $@ -v $(LDFLAGS) $(PACKAGE_NAME)/cmd/apiserver'
+	$(DOCKER_RUN) -e CGO_ENABLED=$(CGO_ENABLED) $(CALICO_BUILD)-$(ARCH) \
+		sh -c '$(GIT_CONFIG_SSH) go build -v -i -o $@-$(ARCH) -v $(LDFLAGS) $(PACKAGE_NAME)/cmd/apiserver'
 
 $(BINDIR)/filecheck: $(K8SAPISERVER_GO_FILES)
 ifndef RELEASE_BUILD
@@ -153,8 +153,8 @@ else
 	$(eval LDFLAGS:=$(BUILD_LDFLAGS))
 endif
 	@echo Building filecheck...
-	$(DOCKER_RUN) -e CGO_ENABLED=$(CGO_ENABLED) $(CALICO_BUILD) \
-		sh -c '$(GIT_CONFIG_SSH) go build -v -i -o $@ -v $(LDFLAGS) $(PACKAGE_NAME)/cmd/filecheck'
+	$(DOCKER_RUN) -e CGO_ENABLED=$(CGO_ENABLED) $(CALICO_BUILD)-$(ARCH) \
+		sh -c '$(GIT_CONFIG_SSH) go build -v -i -o $@-$(ARCH) -v $(LDFLAGS) $(PACKAGE_NAME)/cmd/filecheck'
 
 ###############################################################################
 # Building the image
@@ -163,14 +163,14 @@ build: image
 
 CONTAINER_CREATED=.apiserver.created-$(ARCH)
 .PHONY: image $(API_SERVER_IMAGE)
-image: $(API_SERVER_IMAGE)
+image: register $(API_SERVER_IMAGE)
 image-all: $(addprefix sub-image-,$(VALIDARCHES))
 sub-image-%:
 	$(MAKE) image ARCH=$*
 
 $(API_SERVER_IMAGE): $(CONTAINER_CREATED)
-$(CONTAINER_CREATED): docker-image/Dockerfile.$(ARCH) $(BINDIR)/apiserver
-	docker build -t $(API_SERVER_IMAGE):latest-$(ARCH) --build-arg QEMU_IMAGE=$(CALICO_BUILD) --build-arg GIT_VERSION=$(GIT_VERSION) -f docker-image/Dockerfile.$(ARCH) .
+$(CONTAINER_CREATED): docker-image/Dockerfile.$(ARCH) calico/apiserver
+	docker build --pull -t $(API_SERVER_IMAGE):latest-$(ARCH) --build-arg QEMU_IMAGE=$(CALICO_BUILD) --build-arg GIT_VERSION=$(GIT_VERSION) -f docker-image/Dockerfile.$(ARCH) .
 ifeq ($(ARCH),amd64)
 	docker tag $(API_SERVER_IMAGE):latest-$(ARCH) $(API_SERVER_IMAGE):latest
 endif
@@ -181,17 +181,17 @@ endif
 calico/apiserver: $(BINDIR)/apiserver $(BINDIR)/filecheck
 	rm -rf docker-image/bin
 	mkdir -p docker-image/bin
-	cp $(BINDIR)/apiserver docker-image/bin/
-	cp $(BINDIR)/filecheck docker-image/bin/
-	docker build --pull -t calico/apiserver --file ./docker-image/Dockerfile.$(ARCH) docker-image
+	cp $(BINDIR)/apiserver-$(ARCH) docker-image/bin/
+	cp $(BINDIR)/filecheck-$(ARCH) docker-image/bin/
+	docker build --pull --no-cache --platform linux/$(ARCH) -t calico/apiserver:latest-$(ARCH) --build-arg QEMU_IMAGE=$(CALICO_BUILD) --file ./docker-image/Dockerfile.$(ARCH) docker-image
 
 .PHONY: lint-cache-dir
 lint-cache-dir:
 	mkdir -p $(CURDIR)/.lint-cache
 
-check-boring-ssl: $(BINDIR)/apiserver
+check-boring-ssl: $(BINDIR)/apiserver register
 	$(DOCKER_RUN) -e CGO_ENABLED=$(CGO_ENABLED) $(CALICO_BUILD) \
-		go tool nm $(BINDIR)/apiserver > $(BINDIR)/tags.txt && grep '_Cfunc__goboringcrypto_' $(BINDIR)/tags.txt 1> /dev/null
+		go tool nm $(BINDIR)/apiserver-$(ARCH) > $(BINDIR)/tags.txt && grep '_Cfunc__goboringcrypto_' $(BINDIR)/tags.txt 1> /dev/null
 	-rm -f $(BINDIR)/tags.txt
 
 .PHONY: ut 
@@ -388,7 +388,7 @@ ifneq ($(VERSION), $(GIT_VERSION))
 	$(error Attempt to build $(VERSION) from $(GIT_VERSION))
 endif
 
-	$(MAKE) image RELEASE=true
+	$(MAKE) image-all RELEASE=true
 	$(MAKE) retag-build-images-with-registries IMAGETAG=$(VERSION) RELEASE=true
 	# Generate the `latest` images.
 	$(MAKE) retag-build-images-with-registries IMAGETAG=latest RELEASE=true
@@ -415,7 +415,7 @@ release-publish: release-prereqs
 	git push origin $(VERSION)
 
 	# Push images.
-	$(MAKE) push-images-to-registries push-manifests IMAGETAG=$(VERSION) RELEASE=true CONFIRM=true
+	$(MAKE) image-all push-images-to-registries push-manifests IMAGETAG=$(VERSION) RELEASE=true CONFIRM=true
 
 	@echo "Finalize the GitHub release based on the pushed tag."
 	@echo ""

--- a/docker-image/Dockerfile.arm64
+++ b/docker-image/Dockerfile.arm64
@@ -1,4 +1,9 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1 as ubi
+ARG QEMU_IMAGE
+FROM ${QEMU_IMAGE} as qemu
+
+FROM --platform=linux/arm64 registry.access.redhat.com/ubi8/ubi-minimal:8.1 as ubi
+COPY --from=qemu /usr/bin/qemu-*-static /usr/bin/
+
 RUN microdnf update
 
 # At runtime, apiserver generate certificates in /code directory
@@ -13,8 +18,8 @@ COPY  --from=ubi /tmp /tmp
 COPY  --from=ubi /lib /lib
 COPY  --from=ubi /lib64 /lib64
 
-ADD  bin/apiserver-amd64 /code/apiserver
-ADD  bin/filecheck-amd64 /code/filecheck
+ADD  bin/apiserver-arm64 /code/apiserver
+ADD  bin/filecheck-arm64 /code/filecheck
 
 WORKDIR /code
 


### PR DESCRIPTION
Adding arm64 support to the APIServer image.

## Description
In a multiarch setup apiserver fails to spawn when its assigned to an `arm64` node, this PR offers a solution to this problem.

```release-note
Add Calico API server support for arm64
```
